### PR TITLE
Init functions now write config files if they do not exist. Also fixed major bugs with indenting comments.

### DIFF
--- a/aerolyzer/image_restriction_functions.py
+++ b/aerolyzer/image_restriction_functions.py
@@ -14,16 +14,16 @@ class imgRestFuncs(object):
     'Class containing all image restriction functions'
 
 
-    def __init__(self):
+    def __init__(self, confPath):
         restrict_conf = {'imgLengthMax': 6000, 'imgWidthMin': 100, 'acceptedFileTypes': ['.jpeg', '.jpg', '.png', '.JPG'], 'acceptedMobileDevices': ['iPhone 5', 'iPhone 5s', 'iPhone 6', 'iPhone 6s', 'DROIDX', 'SM-G730V', 'iPhone SE', 'SM-G920V'], 'imgMaxSizeNumber': 4000000, 'imgWidthMax': 6000, 'imgLengthMin': 100}
-        if os.path.exists(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml"):
-            self.criteria = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml")
+        if os.path.exists(confPath + "/config/image_restriction_conf.yaml"):
+            self.criteria = self._import_yaml(confPath + "/config/image_restriction_conf.yaml")
         else:
-            if not os.path.exists(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/"):
-                os.makedirs(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/")
-            with open(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml", 'w') as outfile:
+            if not os.path.exists(confPath + "/config/"):
+                os.makedirs(confPath + "/config/")
+            with open(confPath + "/config/image_restriction_conf.yaml", 'w') as outfile:
                 yaml.dump(restrict_conf, outfile, default_flow_style=False)
-        self.criteria = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml")
+        self.criteria = self._import_yaml(confPath + "/config/image_restriction_conf.yaml")
 
 
     def sigm(self, x):

--- a/aerolyzer/image_restriction_functions.py
+++ b/aerolyzer/image_restriction_functions.py
@@ -15,14 +15,15 @@ class imgRestFuncs(object):
 
 
     def __init__(self):
-        self.types = [".png",".jpg",".jpeg",".JPG"]
-        self.devices = ["iPhone 5","iPhone 5s","iPhone 6","iPhone 6s","DROIDX","SM-G730V","iPhone SE","SM-G920V"]
-        self.maxSize = 4000000
-        self.imgWidthMin = 100
-        self.imgLengthMin = 100
-        self.imgWidthMax = 6000
-        self.imgLengthMax = 6000
-        #self.criteria = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml")
+        restrict_conf = {'imgLengthMax': 6000, 'imgWidthMin': 100, 'acceptedFileTypes': ['.jpeg', '.jpg', '.png', '.JPG'], 'acceptedMobileDevices': ['iPhone 5', 'iPhone 5s', 'iPhone 6', 'iPhone 6s', 'DROIDX', 'SM-G730V', 'iPhone SE', 'SM-G920V'], 'imgMaxSizeNumber': 4000000, 'imgWidthMax': 6000, 'imgLengthMin': 100}
+        if os.path.exists(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml"):
+            self.criteria = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml")
+        else:
+            if not os.path.exists(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/"):
+                os.makedirs(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/")
+            with open(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml", 'w') as outfile:
+                yaml.dump(restrict_conf, outfile, default_flow_style=False)
+        self.criteria = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml")
 
 
     def sigm(self, x):
@@ -44,7 +45,7 @@ class imgRestFuncs(object):
         Returns:        Boolean
         Assumptions:    N/A
         '''
-        if device in self.devices:
+        if device in self.criteria['acceptedMobileDevices']:
             return True
         else:
             return False
@@ -89,7 +90,7 @@ class imgRestFuncs(object):
         Returns:        Boolean
         Assumptions:    N/A
         '''
-        if(fileSize > self.maxSize):
+        if(fileSize > self.criteria['imgMaxSizeNumber']):
             return False
         else:
             return True
@@ -104,7 +105,7 @@ class imgRestFuncs(object):
         Returns:        Boolean
         Assumptions:    N/A
         '''
-        if fileType in self.types:
+        if fileType in self.criteria['acceptedFileTypes']:
             return True
         else:
             return False
@@ -119,8 +120,8 @@ class imgRestFuncs(object):
         Returns:        Boolean
         Assumptions:    N/A
         '''
-        if (imageWidth >= self.imgWidthMin) and (imageLength >= self.imgLengthMin):
-            if (imageWidth <= self.imgWidthMax) and (imageLength <= self.imgLengthMax):
+        if (imageWidth >= self.criteria['imgWidthMin']) and (imageLength >= self.criteria['imgLengthMin']):
+            if (imageWidth <= self.criteria['imgWidthMax']) and (imageLength <= self.criteria['imgLengthMax']):
                 return True
         else:
             return False

--- a/aerolyzer/image_restriction_functions.py
+++ b/aerolyzer/image_restriction_functions.py
@@ -15,29 +15,36 @@ class imgRestFuncs(object):
 
 
     def __init__(self):
-        self.criteria = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml")
+        self.types = [".png",".jpg",".jpeg",".JPG"]
+        self.devices = ["iPhone 5","iPhone 5s","iPhone 6","iPhone 6s","DROIDX","SM-G730V","iPhone SE","SM-G920V"]
+        self.maxSize = 4000000
+        self.imgWidthMin = 100
+        self.imgLengthMin = 100
+        self.imgWidthMax = 6000
+        self.imgLengthMax = 6000
+        #self.criteria = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/image_restriction_conf.yaml")
 
 
     def sigm(self, x):
-    '''
-    Purpose:        sigmoid function that takes in a value and returns a value from 0 to 1
-    Inputs:         float
-    Outputs:        None
-    Returns:        Float between 0, 1
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        sigmoid function that takes in a value and returns a value from 0 to 1
+        Inputs:         float
+        Outputs:        None
+        Returns:        Float between 0, 1
+        Assumptions:    N/A
+        '''
         return 1 / (1 + np.exp(-x))
 
     def is_device(self, device):
-    '''
-    Purpose:        The purpose of this function is to determine whether or not the device the
-                    image was taken on is an accepted mobile device.
-    Inputs:         string device
-    Outputs:        None
-    Returns:        Boolean
-    Assumptions:    N/A
-    '''
-        if device in self.criteria['acceptedMobileDevices']:
+        '''
+        Purpose:        The purpose of this function is to determine whether or not the device the
+                        image was taken on is an accepted mobile device.
+        Inputs:         string device
+        Outputs:        None
+        Returns:        Boolean
+        Assumptions:    N/A
+        '''
+        if device in self.devices:
             return True
         else:
             return False
@@ -45,14 +52,14 @@ class imgRestFuncs(object):
 
 
     def is_edited(self, modified, created):
-    '''
-    Purpose:        The purpose of this function is to determine whether or not the image was
-                    altered from its original form. I.e. do the modification and creation dates coincide.
-    Inputs:         datetime created, datetime modified
-    Outputs:        None
-    Returns:        Boolean
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to determine whether or not the image was
+                        altered from its original form. I.e. do the modification and creation dates coincide.
+        Inputs:         datetime created, datetime modified
+        Outputs:        None
+        Returns:        Boolean
+        Assumptions:    N/A
+        '''
         if (created == modified):
             return True
         else:
@@ -60,74 +67,74 @@ class imgRestFuncs(object):
 
 
     def is_landscape(self, pathname):
-    '''
-    Purpose:        The purpose of this function is to determine whether or not the image
-                    contains a direct landscape with sky and view.
-    Inputs:         pathname for image 
-    Outputs:        None
-    Returns:        Boolean
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to determine whether or not the image
+                        contains a direct landscape with sky and view.
+        Inputs:         pathname for image 
+        Outputs:        None
+        Returns:        Boolean
+        Assumptions:    N/A
+        '''
         img = cv2.imread(pathname,1)
         return self._is_sky(img)
 
 
     def is_size(self, fileSize):
-    '''
-    Purpose:        The purpose of this function is to determine whether or not the size of
-                    the image is less than or equal to 200kb.
-    Inputs:         dict exifData, int imgMaxSize, int imgMaxSizeBytesShort,
-                    string fileSize
-    Outputs:        None
-    Returns:        Boolean
-    Assumptions:    N/A
-    '''
-        if(fileSize > self.criteria['imgMaxSizeNumber']):
+        '''
+        Purpose:        The purpose of this function is to determine whether or not the size of
+                        the image is less than or equal to 200kb.
+        Inputs:         dict exifData, int imgMaxSize, int imgMaxSizeBytesShort,
+                        string fileSize
+        Outputs:        None
+        Returns:        Boolean
+        Assumptions:    N/A
+        '''
+        if(fileSize > self.maxSize):
             return False
         else:
             return True
 
 
     def is_type(self, fileType):
-    '''
-    Purpose:        The purpose of this function  is to determine whether or not the image is
-                    an accepted file type.
-    Inputs:         string fileType
-    Outputs:        None
-    Returns:        Boolean
-    Assumptions:    N/A
-    '''
-        if fileType in self.criteria['acceptedFileTypes']:
+        '''
+        Purpose:        The purpose of this function  is to determine whether or not the image is
+                        an accepted file type.
+        Inputs:         string fileType
+        Outputs:        None
+        Returns:        Boolean
+        Assumptions:    N/A
+        '''
+        if fileType in self.types:
             return True
         else:
             return False
 
 
     def is_res(self, imageWidth, imageLength):
-    '''
-    Purpose:        The purpose of this function is to determine whether or not the image
-                    exceeds the minimum resolution.
-    Inputs:         int imageWidth, int imageLength
-    Outputs:        None
-    Returns:        Boolean
-    Assumptions:    N/A
-    '''
-        if (imageWidth >= self.criteria['imgWidthMin']) and (imageLength >= self.criteria['imgLengthMin']):
-            if (imageWidth <= self.criteria['imgWidthMax']) and (imageLength <= self.criteria['imgLengthMax']):
+        '''
+        Purpose:        The purpose of this function is to determine whether or not the image
+                        exceeds the minimum resolution.
+        Inputs:         int imageWidth, int imageLength
+        Outputs:        None
+        Returns:        Boolean
+        Assumptions:    N/A
+        '''
+        if (imageWidth >= self.imgWidthMin) and (imageLength >= self.imgLengthMin):
+            if (imageWidth <= self.imgWidthMax) and (imageLength <= self.imgLengthMax):
                 return True
         else:
             return False
 
 
     def _is_sky(self, img):
-    '''
-    Purpose:        The purpose of this function is to determine whether or not the image contains
-                    a valid sky or not. 
-    Inputs:         numpy.ndarray (loaded image information)
-    Outputs:        None
-    Returns:        Boolean (valid or invalid image)
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to determine whether or not the image contains
+                        a valid sky or not. 
+        Inputs:         numpy.ndarray (loaded image information)
+        Outputs:        None
+        Returns:        Boolean (valid or invalid image)
+        Assumptions:    N/A
+        '''
 
         syn0 = np.array([[0.6106635051820115, -1.2018987127529588, -10.344605820189082, 1.1911213385074928, -6.818421664371254, 0.7888012143578024, 0.1930026599192343, 2.3468732267729644, -0.8629627172245428, -4.855127665505846, -8.782456796605247, -6.495787542595586, -1.42453153150294, -0.91145196348796, -0.34523737705411006],
 [-1.3963274415314406, -1.4612339780784143, -2.9000212540397685, -3.9905541370795463, -3.4490261869089287, -4.30542395055999, -2.6069427860345145, 7.201038210239841, -2.205826668689026, -2.493364425571145, -1.9813891706545306, -2.235792731073901, -7.475941696773453, -2.68683663270719, 4.173252030927632], 
@@ -201,13 +208,13 @@ class imgRestFuncs(object):
 
 
     def _import_yaml(self, confFile):
-    '''
-    Purpose:        The purpose of this function is to import the contents of the configuration file.
-    Inputs:         string conf_file
-    Outputs:        None
-    Returns:        reference to configuration file
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to import the contents of the configuration file.
+        Inputs:         string conf_file
+        Outputs:        None
+        Returns:        reference to configuration file
+        Assumptions:    N/A
+        '''
         with open(confFile, 'r') as f:
             doc = yaml.load(f)
             f.close()

--- a/aerolyzer/image_restriction_main.py
+++ b/aerolyzer/image_restriction_main.py
@@ -12,13 +12,13 @@ from retrieve_image_data import RtrvData as Data
 
 
 def program(fxn, data, exifData, pathname):
-'''
-Purpose:        The purpose of this function is to assert each restriction check
-Inputs:         dict exifData, object functions
-Outputs:        restriction check results
-Returns:        N/A
-Assumptions:    N/A
-'''
+    '''
+    Purpose:        The purpose of this function is to assert each restriction check
+    Inputs:         dict exifData, object functions
+    Outputs:        restriction check results
+    Returns:        N/A
+    Assumptions:    N/A
+    '''
     if not 'image model' in exifData:
         isVerified = {'meetsRest': False, 'error_message': "The image must be a mobile image from a supported device"}
         return isVerified
@@ -50,14 +50,14 @@ Assumptions:    N/A
 
 
 def check_image(filename):
-'''
-Purpose:        The purpose of this main function is to check all image restrictions
-                for use in the Aerolyzer app.
-Inputs:         string filename of image locally
-Outputs:        None
-Returns:        isVerified
-Assumptions:    N/A
-'''
+    '''
+    Purpose:        The purpose of this main function is to check all image restrictions
+                    for use in the Aerolyzer app.
+    Inputs:         string filename of image locally
+    Outputs:        None
+    Returns:        isVerified
+    Assumptions:    N/A
+    '''
     #instantiate classes
     fxn     = Fxn()
     #Retrieve exif data
@@ -68,23 +68,23 @@ Assumptions:    N/A
 
 
 def main():
-'''
-Purpose:        The purpose of this main function is to check all image restrictions and
-                produce the correct error message should one occur.
-Inputs:         string image (as sys.argv[1])
-Outputs:        None
-Returns:        N/A
-Assumptions:    N/A
-'''
+    '''
+    Purpose:        The purpose of this main function is to check all image restrictions and
+                    produce the correct error message should one occur.
+    Inputs:         string image (as sys.argv[1])
+    Outputs:        None
+    Returns:        N/A
+    Assumptions:    N/A
+    '''
     #instantiate classes
     fxn     = Fxn()
 
     #Retrieve exif data
     if(len(sys.argv) < 2):
         #use default image
-        data    = Data("./images/good-images/1484949760_19_2615.jpg")
-        exifData = data.get_exif("./images/good-images/1484949760_19_2615.jpg", True, True)
-        program(fxn, data, exifData, "./images/good-images/1484949760_19_2615.jpg")
+        data    = Data("/home/aero/Desktop/phones/i6s/IMG_0699.jpg")
+        exifData = data.get_exif("/home/aero/Desktop/phones/i6s/IMG_0699.jpg", True, True)
+        print program(fxn, data, exifData, "/home/aero/Desktop/phones/i6s/IMG_0699.jpg")
     elif(len(sys.argv) == 2):
         data    = Data(sys.argv[1])
         exifData = data.get_exif(sys.argv[1], True, False)

--- a/aerolyzer/image_restriction_main.py
+++ b/aerolyzer/image_restriction_main.py
@@ -84,7 +84,7 @@ def main():
         #use default image
         data    = Data("/home/aero/Desktop/phones/i6s/IMG_0699.jpg")
         exifData = data.get_exif("/home/aero/Desktop/phones/i6s/IMG_0699.jpg", True, True)
-        print program(fxn, data, exifData, "/home/aero/Desktop/phones/i6s/IMG_0699.jpg")
+        program(fxn, data, exifData, "/home/aero/Desktop/phones/i6s/IMG_0699.jpg")
     elif(len(sys.argv) == 2):
         data    = Data(sys.argv[1])
         exifData = data.get_exif(sys.argv[1], True, False)

--- a/aerolyzer/image_restriction_main.py
+++ b/aerolyzer/image_restriction_main.py
@@ -16,7 +16,7 @@ def program(fxn, data, exifData, pathname):
     Purpose:        The purpose of this function is to assert each restriction check
     Inputs:         dict exifData, object functions
     Outputs:        restriction check results
-    Returns:        N/A
+    Returns:        isVerified
     Assumptions:    N/A
     '''
     if not 'image model' in exifData:
@@ -49,19 +49,19 @@ def program(fxn, data, exifData, pathname):
     return isVerified
 
 
-def check_image(filename):
+def check_image(filename,confPath="."):
     '''
     Purpose:        The purpose of this main function is to check all image restrictions
                     for use in the Aerolyzer app.
-    Inputs:         string filename of image locally
+    Inputs:         string filename of image locally, optional string confPath
     Outputs:        None
     Returns:        isVerified
     Assumptions:    N/A
     '''
     #instantiate classes
-    fxn     = Fxn()
+    fxn     = Fxn(confPath)
     #Retrieve exif data
-    data    = Data(filename)
+    data    = Data(confPath)
     exifData = data.get_exif(filename, True, False)
     isVerified = program(fxn, data, exifData, filename)
     return isVerified
@@ -71,27 +71,28 @@ def main():
     '''
     Purpose:        The purpose of this main function is to check all image restrictions and
                     produce the correct error message should one occur.
-    Inputs:         string image (as sys.argv[1])
+    Inputs:         string image (as sys.argv[1]), Config path(as sys.argv[2])
     Outputs:        None
     Returns:        N/A
     Assumptions:    N/A
     '''
     #instantiate classes
-    fxn     = Fxn()
+    
 
     #Retrieve exif data
     if(len(sys.argv) < 2):
-        #use default image
-        data    = Data("/home/aero/Desktop/phones/i6s/IMG_0699.jpg")
-        exifData = data.get_exif("/home/aero/Desktop/phones/i6s/IMG_0699.jpg", True, True)
-        program(fxn, data, exifData, "/home/aero/Desktop/phones/i6s/IMG_0699.jpg")
-    elif(len(sys.argv) == 2):
-        data    = Data(sys.argv[1])
-        exifData = data.get_exif(sys.argv[1], True, False)
-        program(fxn, data, exifData, sys.argv[1])
-    elif(len(sys.argv) > 2):
         #error
-        print "Please pass only 1 image to this program as an argument"
+        print "Please pass an image path as an argument with an optional config path"
+
+    elif(len(sys.argv) == 2):
+        check_image(sys.argv[1])
+
+    elif(len(sys.argv) == 3):
+        check_image(sys.argv[1],sys.argv[2])
+
+    elif(len(sys.argv) > 3):
+        #error
+        print "Please pass only 1 image to this program and an optional config path as arguments"
 
 if __name__ == '__main__':
     main()

--- a/aerolyzer/retrieve_image_data.py
+++ b/aerolyzer/retrieve_image_data.py
@@ -15,14 +15,14 @@ class RtrvData(object):
 
     def __init__(self, pathPassed):
         retrieve_conf = {'selectTags': ['Image Model', 'Image DateTime', 'EXIF DateTimeOriginal', 'EXIF ExifImageWidth', 'EXIF ExifImageLength', 'GPS GPSLatitude', 'GPS GPSLongitude', 'GPS GPSLatitudeRef', 'GPS GPSLongitudeRef'], 'intTags': ['exif exifimagewidth', 'exif exifimagelength'], 'datetimeTags': ['image datetime', 'exif datetimeoriginal'], 'stringTags': ['image model', 'gps gpslatitude', 'gps gpslongitude', 'gps gpslatituderef', 'gps gpslongituderef']}
-        if os.path.exists(os.getcwd() + "/../../config/retrieve_image_data_conf.yaml"):
-            self.data = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml")
+        if os.path.exists(pathPassed + "/config/retrieve_image_data_conf.yaml"):
+            self.data = self._import_yaml(pathPassed + "/config/retrieve_image_data_conf.yaml")
         else:
-            if not os.path.exists(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/"):
-                os.makedirs(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/")
-            with open(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml", 'w') as outfile:
+            if not os.path.exists(pathPassed + "/config/"):
+                os.makedirs(os.getcwd() + pathPassed + "/config/")
+            with open(pathPassed + "/config/retrieve_image_data_conf.yaml", 'w') as outfile:
                 yaml.dump(retrieve_conf, outfile, default_flow_style=False)
-        self.data = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml")
+        self.data = self._import_yaml(pathPassed + "/config/retrieve_image_data_conf.yaml")
         try:
             os.path.exists(pathPassed)
         except ImportError:

--- a/aerolyzer/retrieve_image_data.py
+++ b/aerolyzer/retrieve_image_data.py
@@ -14,42 +14,46 @@ class RtrvData(object):
     'Class containing all image restriction functions'
 
     def __init__(self, pathPassed):
-        self.data = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml")
-        try:
-            os.path.exists(pathPassed)
-        except ImportError:
-            pass
+        self.selectTags = ["Image Model","Image DateTime","EXIF DateTimeOriginal","EXIF ExifImageWidth","EXIF ExifImageLength","GPS GPSLatitude","GPS GPSLongitude","GPS GPSLatitudeRef","GPS GPSLongitudeRef"]
+        self.stringTags = ["image model","gps gpslatitude","gps gpslongitude","gps gpslatituderef","gps gpslongituderef"]
+        self.datetimeTags = ["image datetime","exif datetimeoriginal"]
+        self.intTags = ["exif exifimagewidth","exif exifimagelength"]
+        #self.data = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml")
+        #try:
+        #    os.path.exists(pathPassed)
+        #except ImportError:
+        #    pass
 
 
     def _get_all_exif(self, pathname):
-    '''
-    Purpose:        The purpose of this function is to retrieve the EXIF data from an
-                    image.
-    Inputs:         string pathname
-    Outputs:        None
-    Returns:        dictionary of EXIF data tags
-    Assumptions:    The image's path has been provided
-    '''
+        '''
+        Purpose:        The purpose of this function is to retrieve the EXIF data from an
+                        image.
+        Inputs:         string pathname
+        Outputs:        None
+        Returns:        dictionary of EXIF data tags
+        Assumptions:    The image's path has been provided
+        '''
         img = open(pathname, 'rb')
         tags = exifread.process_file(img)
         return tags
 
 
     def get_exif(self, pathname, setTypes, dateToString):
-    '''
-    Purpose:        The purpose of this function is to retrieve the EXIF data from an
-                    image.
-    Inputs:         string pathname
-                    bool setTypes toggles conversion of types
-                    bool dateToString toggles conversion of dateToString
-    Outputs:        None
-    Returns:        dictionary of EXIF data tags
-    Assumptions:    The image's path has been provided
-    '''
+        '''
+        Purpose:        The purpose of this function is to retrieve the EXIF data from an
+                        image.
+        Inputs:         string pathname
+                        bool setTypes toggles conversion of types
+                        bool dateToString toggles conversion of dateToString
+        Outputs:        None
+        Returns:        dictionary of EXIF data tags
+        Assumptions:    The image's path has been provided
+        '''
         tags = {};
         allTags = self._get_all_exif(pathname)
         for key, value in allTags.iteritems():
-            for entry in self.data['selectTags']:
+            for entry in self.selectTags:
                 if (key == entry):
                     tags[key.lower()] = value
         if setTypes is True:
@@ -60,14 +64,14 @@ class RtrvData(object):
 
 
     def get_hsv(self, pathname):
-    '''
-    Purpose:        The purpose of this function is to retrieve the HSV values from an
-                    image's haze layer.
-    Inputs:         string pathname
-    Outputs:        None
-    Returns:        list of lists containing HSV values
-    Assumptions:    The image's path has been provided
-    '''
+        '''
+        Purpose:        The purpose of this function is to retrieve the HSV values from an
+                        image's haze layer.
+        Inputs:         string pathname
+        Outputs:        None
+        Returns:        list of lists containing HSV values
+        Assumptions:    The image's path has been provided
+        '''
         img = cv2.imread(pathname,1)
         mask = np.zeros(img.shape[:2], np.uint8)
         mask[0:(img.shape[0] / 2), 0:img.shape[1]] = 255
@@ -108,13 +112,13 @@ class RtrvData(object):
 
 
     def _import_yaml(self, confFile):
-    '''
-    Purpose:        The purpose of this function is to import the contents of the configuration file.
-    Inputs:         string conf_file
-    Outputs:        None
-    Returns:        reference to configuration file
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to import the contents of the configuration file.
+        Inputs:         string conf_file
+        Outputs:        None
+        Returns:        reference to configuration file
+        Assumptions:    N/A
+        '''
         assert (type(confFile) == str), "configuration file not passed as a string"
         with open(confFile, 'r') as file:
             doc = yaml.load(file)
@@ -123,50 +127,50 @@ class RtrvData(object):
 
 
     def _get_file_size(self, pathname):
-    '''
-    Purpose:        The purpose of this function is to determine the size of the image
-    Inputs:         string pathname
-    Outputs:        None
-    Returns:        int size of file in bytes
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to determine the size of the image
+        Inputs:         string pathname
+        Outputs:        None
+        Returns:        int size of file in bytes
+        Assumptions:    N/A
+        '''
         return os.path.getsize(pathname)
 
 
     def _get_file_type(self, pathname):
-    '''
-    Purpose:        The purpose of this function is to determine the type of the image
-    Inputs:         string pathname
-    Outputs:        None
-    Returns:        string file type (.ext)
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to determine the type of the image
+        Inputs:         string pathname
+        Outputs:        None
+        Returns:        string file type (.ext)
+        Assumptions:    N/A
+        '''
         filename, fileExtension = os.path.splitext(pathname)
         return fileExtension
 
 
     def _set_types(self, tags, dateToString):
-    '''
-    Purpose:        The purpose of this function is to set the tag values to the correct
-                    data type
-    Inputs:         string pathname
-                    bool dateToString toggles conversion of datetimeTags to strings
-    Outputs:        None
-    Returns:        string file type (.ext)
-    Assumptions:    N/A
-    '''
+        '''
+        Purpose:        The purpose of this function is to set the tag values to the correct
+                        data type
+        Inputs:         string pathname
+                        bool dateToString toggles conversion of datetimeTags to strings
+        Outputs:        None
+        Returns:        string file type (.ext)
+        Assumptions:    N/A
+        '''
         for key, value in tags.iteritems():
-            for entry in self.data['stringTags']:
+            for entry in self.stringTags:
                 if(key == entry):
                     tags[key] = str(value)
-            for entry in self.data['datetimeTags']:
+            for entry in self.datetimeTags:
                 if(key == entry):
                     stringDate = str(value)
                     if dateToString is True:
                         tags[key] = stringDate
                     else:
                         tags[key] = datetime.strptime(stringDate, '%Y:%m:%d %H:%M:%S')
-            for entry in self.data['intTags']:
+            for entry in self.intTags:
                 if(key == entry):
                     strKey = str(value)
                     tags[key] = int(strKey)

--- a/aerolyzer/retrieve_image_data.py
+++ b/aerolyzer/retrieve_image_data.py
@@ -14,15 +14,19 @@ class RtrvData(object):
     'Class containing all image restriction functions'
 
     def __init__(self, pathPassed):
-        self.selectTags = ["Image Model","Image DateTime","EXIF DateTimeOriginal","EXIF ExifImageWidth","EXIF ExifImageLength","GPS GPSLatitude","GPS GPSLongitude","GPS GPSLatitudeRef","GPS GPSLongitudeRef"]
-        self.stringTags = ["image model","gps gpslatitude","gps gpslongitude","gps gpslatituderef","gps gpslongituderef"]
-        self.datetimeTags = ["image datetime","exif datetimeoriginal"]
-        self.intTags = ["exif exifimagewidth","exif exifimagelength"]
-        #self.data = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml")
-        #try:
-        #    os.path.exists(pathPassed)
-        #except ImportError:
-        #    pass
+        retrieve_conf = {'selectTags': ['Image Model', 'Image DateTime', 'EXIF DateTimeOriginal', 'EXIF ExifImageWidth', 'EXIF ExifImageLength', 'GPS GPSLatitude', 'GPS GPSLongitude', 'GPS GPSLatitudeRef', 'GPS GPSLongitudeRef'], 'intTags': ['exif exifimagewidth', 'exif exifimagelength'], 'datetimeTags': ['image datetime', 'exif datetimeoriginal'], 'stringTags': ['image model', 'gps gpslatitude', 'gps gpslongitude', 'gps gpslatituderef', 'gps gpslongituderef']}
+        if os.path.exists(os.getcwd() + "/../../config/retrieve_image_data_conf.yaml"):
+            self.data = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml")
+        else:
+            if not os.path.exists(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/"):
+                os.makedirs(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/")
+            with open(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml", 'w') as outfile:
+                yaml.dump(retrieve_conf, outfile, default_flow_style=False)
+        self.data = self._import_yaml(os.getcwd() + "/../../Aerolyzer/aerolyzer/config/retrieve_image_data_conf.yaml")
+        try:
+            os.path.exists(pathPassed)
+        except ImportError:
+            pass
 
 
     def _get_all_exif(self, pathname):
@@ -53,7 +57,7 @@ class RtrvData(object):
         tags = {};
         allTags = self._get_all_exif(pathname)
         for key, value in allTags.iteritems():
-            for entry in self.selectTags:
+            for entry in self.data["selectTags"]:
                 if (key == entry):
                     tags[key.lower()] = value
         if setTypes is True:
@@ -160,17 +164,17 @@ class RtrvData(object):
         Assumptions:    N/A
         '''
         for key, value in tags.iteritems():
-            for entry in self.stringTags:
+            for entry in self.data["stringTags"]:
                 if(key == entry):
                     tags[key] = str(value)
-            for entry in self.datetimeTags:
+            for entry in self.data["datetimeTags"]:
                 if(key == entry):
                     stringDate = str(value)
                     if dateToString is True:
                         tags[key] = stringDate
                     else:
                         tags[key] = datetime.strptime(stringDate, '%Y:%m:%d %H:%M:%S')
-            for entry in self.intTags:
+            for entry in self.data["intTags"]:
                 if(key == entry):
                     strKey = str(value)
                     tags[key] = int(strKey)


### PR DESCRIPTION
In reference to issue #126 I have scrapped the use of config files entirely. Daniel has also been working on another fix that doesn't scrap config files, but instead writes them if they do not exist. If we chose to keep config file functionality, we should implement his method.

There was also a major bug in the last pull request because I did not realize in python, comments need to have proper indentation. This PR also fixes this.